### PR TITLE
Speed up compilation-time by using forward-declarations.

### DIFF
--- a/engine/src/Core/ResourceManager.cpp
+++ b/engine/src/Core/ResourceManager.cpp
@@ -10,8 +10,12 @@
 
 #include <Core/Root.hpp>
 #include <Utils/Utils.hpp>
+#include <Utils/LogManager.hpp>
+#include <Graphics/DisplayManager.hpp>
 
 #include <QCoreApplication>
+
+#include <Ogre.h>
 
 namespace dt {
 

--- a/engine/src/Core/Root.cpp
+++ b/engine/src/Core/Root.cpp
@@ -8,6 +8,18 @@
 
 #include <Core/Root.hpp>
 
+#include <Utils/LogManager.hpp>
+#include <Core/StringManager.hpp>
+#include <Event/EventManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Input/InputManager.hpp>
+#include <Graphics/DisplayManager.hpp>
+#include <Scene/StateManager.hpp>
+#include <Network/NetworkManager.hpp>
+#include <Physics/PhysicsManager.hpp>
+#include <Graphics/TerrainManager.hpp>
+#include <Logic/ScriptManager.hpp>
+
 namespace dt {
 
 QString Root::_VERSION = DUCTTAPE_VERSION;

--- a/engine/src/Core/Root.hpp
+++ b/engine/src/Core/Root.hpp
@@ -37,23 +37,25 @@
 
 #include <Config.hpp>
 
-#include <Utils/LogManager.hpp>
-#include <Core/StringManager.hpp>
-#include <Event/EventManager.hpp>
-#include <Core/ResourceManager.hpp>
-#include <Input/InputManager.hpp>
-#include <Graphics/DisplayManager.hpp>
-#include <Scene/StateManager.hpp>
-#include <Network/NetworkManager.hpp>
-#include <Physics/PhysicsManager.hpp>
-#include <Graphics/TerrainManager.hpp>
-#include <Logic/ScriptManager.hpp>
-
 #include <boost/noncopyable.hpp>
 
 #include <SFML/System/Clock.hpp>
 
+#include <qcoreapplication.h>
+
 namespace dt {
+
+class LogManager;
+class StringManager;
+class EventManager;
+class ResourceManager;
+class InputManager;
+class DisplayManager;
+class StateManager;
+class NetworkManager;
+class PhysicsManager;
+class TerrainManager;
+class ScriptManager;
 
 /**
   * Engine Root class holding various Manager instances. This class is designed to be the only singleton in the whole engine,

--- a/engine/src/Event/EventManager.cpp
+++ b/engine/src/Event/EventManager.cpp
@@ -9,6 +9,7 @@
 #include <Event/EventManager.hpp>
 
 #include <Core/Root.hpp>
+#include <Utils/LogManager.hpp>
 
 namespace dt {
 

--- a/engine/src/Graphics/DisplayManager.cpp
+++ b/engine/src/Graphics/DisplayManager.cpp
@@ -9,6 +9,8 @@
 #include <Graphics/DisplayManager.hpp>
 
 #include <Core/Root.hpp>
+#include <Utils/LogManager.hpp>
+#include <Input/InputManager.hpp>
 
 #include <SFML/Window/VideoMode.hpp>
 

--- a/engine/src/Graphics/TerrainManager.hpp
+++ b/engine/src/Graphics/TerrainManager.hpp
@@ -25,7 +25,7 @@
 namespace dt {
 
 /**
-  * A manager class for managing the display and rendering.
+  * A manager class for managing terrain.
   */
 class DUCTTAPE_API TerrainManager : public Manager {
     Q_OBJECT

--- a/engine/src/Input/InputManager.cpp
+++ b/engine/src/Input/InputManager.cpp
@@ -14,6 +14,8 @@
 #include <Input/KeyboardEvent.hpp>
 #include <Graphics/WindowClosedEvent.hpp>
 #include <Utils/Utils.hpp>
+#include <Event/EventManager.hpp>
+#include <Gui/GuiManager.hpp>
 
 namespace dt {
 

--- a/engine/src/Logic/ScriptManager.cpp
+++ b/engine/src/Logic/ScriptManager.cpp
@@ -15,6 +15,8 @@
 #include <Utils/Utils.hpp>
 #include <Input/MouseState.hpp>
 #include <Input/KeyboardState.hpp>
+#include <Graphics/DisplayManager.hpp>
+#include <Core/ResourceManager.hpp>
 
 #include <QTextStream>
 

--- a/engine/src/Network/ConnectionsManager.cpp
+++ b/engine/src/Network/ConnectionsManager.cpp
@@ -14,6 +14,7 @@
 #include <Network/NetworkManager.hpp>
 #include <Utils/TimerTickEvent.hpp>
 #include <Utils/Utils.hpp>
+#include <Utils/LogManager.hpp>
 
 namespace dt {
 

--- a/engine/src/Network/NetworkManager.cpp
+++ b/engine/src/Network/NetworkManager.cpp
@@ -13,6 +13,8 @@
 #include <Network/HandshakeEvent.hpp>
 #include <Network/GoodbyeEvent.hpp>
 #include <Utils/Utils.hpp>
+#include <Utils/LogManager.hpp>
+#include <Core/StringManager.hpp>
 
 namespace dt {
 

--- a/engine/src/Scene/Game.cpp
+++ b/engine/src/Scene/Game.cpp
@@ -11,6 +11,11 @@
 #include <Core/Root.hpp>
 #include <Event/BeginFrameEvent.hpp>
 #include <Network/GoodbyeEvent.hpp>
+#include <Event/EventManager.hpp>
+#include <Scene/StateManager.hpp>
+#include <Input/InputManager.hpp>
+#include <Network/NetworkManager.hpp>
+#include <Graphics/DisplayManager.hpp>
 
 #include <SFML/System/Sleep.hpp>
 

--- a/samples/chat/src/client/Client.cpp
+++ b/samples/chat/src/client/Client.cpp
@@ -12,6 +12,10 @@
 
 #include <Core/Root.hpp>
 #include <Utils/Utils.hpp>
+#include <Event/EventManager.hpp>
+#include <Network/NetworkManager.hpp>
+#include <Network/ConnectionsManager.hpp>
+#include <Scene/StateManager.hpp>
 
 Client::Client() {
     mServerIP = sf::IpAddress::LocalHost;

--- a/samples/chat/src/server/Server.cpp
+++ b/samples/chat/src/server/Server.cpp
@@ -11,6 +11,8 @@
 #include <Core/Root.hpp>
 #include <Network/GoodbyeEvent.hpp>
 #include <Utils/Utils.hpp>
+#include <Event/EventManager.hpp>
+#include <Network/NetworkManager.hpp>
 
 #include "ChatMessageEvent.hpp"
 

--- a/samples/script/src/main.cpp
+++ b/samples/script/src/main.cpp
@@ -15,6 +15,10 @@
 #include <Gui/GuiButton.hpp>
 #include <Gui/GuiEditBox.hpp>
 #include <Utils/Utils.hpp>
+#include <Graphics/DisplayManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Logic/ScriptManager.hpp>
+#include <Scene/StateManager.hpp>
 
 #include <QList>
 #include <QString>

--- a/samples/simplepong/src/main.cpp
+++ b/samples/simplepong/src/main.cpp
@@ -10,10 +10,14 @@
 #include <Graphics/LightComponent.hpp>
 #include <Graphics/MeshComponent.hpp>
 #include <Graphics/TextComponent.hpp>
+#include <Graphics/CameraComponent.hpp>
 #include <Scene/Game.hpp>
 #include <Scene/Node.hpp>
 #include <Scene/Scene.hpp>
 #include <Utils/Utils.hpp>
+#include <Event/BeginFrameEvent.hpp>
+#include <Input/InputManager.hpp>
+#include <Core/ResourceManager.hpp>
 
 #include <OgreFontManager.h>
 #include <OgreVector3.h>

--- a/tests/src/DisplayTest/DisplayTest.cpp
+++ b/tests/src/DisplayTest/DisplayTest.cpp
@@ -8,6 +8,11 @@
 
 #include "DisplayTest/DisplayTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace DisplayTest {
 
 bool DisplayTest::Run(int argc, char** argv) {

--- a/tests/src/EventBindingsTest/EventBindingsTest.cpp
+++ b/tests/src/EventBindingsTest/EventBindingsTest.cpp
@@ -9,6 +9,8 @@
 #include "EventBindingsTest/EventBindingsTest.hpp"
 
 #include <Utils/Utils.hpp>
+#include <Core/StringManager.hpp>
+#include <Event/EventManager.hpp>
 
 namespace EventBindingsTest {
 

--- a/tests/src/EventsTest/EventsTest.cpp
+++ b/tests/src/EventsTest/EventsTest.cpp
@@ -8,6 +8,9 @@
 
 #include "EventsTest/EventsTest.hpp"
 
+#include <Core/StringManager.hpp>
+#include <Event/EventManager.hpp>
+
 namespace EventsTest {
 
 bool EventsTest::Run(int argc, char** argv) {

--- a/tests/src/FollowPathTest/FollowPathTest.cpp
+++ b/tests/src/FollowPathTest/FollowPathTest.cpp
@@ -8,6 +8,11 @@
 
 #include "FollowPathTest/FollowPathTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace FollowPathTest {
 
 bool FollowPathTest::Run(int argc, char** argv) {

--- a/tests/src/GuiTest/GuiTest.cpp
+++ b/tests/src/GuiTest/GuiTest.cpp
@@ -8,6 +8,12 @@
 
 #include "GuiTest/GuiTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+#include <Gui/GuiManager.hpp>
+
 namespace GuiTest {
 
 bool GuiTest::Run(int argc, char** argv) {

--- a/tests/src/InputTest/InputTest.cpp
+++ b/tests/src/InputTest/InputTest.cpp
@@ -8,6 +8,12 @@
 
 #include "InputTest/InputTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Input/InputManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+#include <Scene/StateManager.hpp>
+
 namespace InputTest {
 
 bool InputTest::Run(int argc, char** argv) {

--- a/tests/src/MouseCursorTest/MouseCursorTest.cpp
+++ b/tests/src/MouseCursorTest/MouseCursorTest.cpp
@@ -8,6 +8,12 @@
 
 #include "MouseCursorTest/MouseCursorTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+#include <Input/InputManager.hpp>
+
 namespace MouseCursorTest {
 
 bool MouseCursorTest::Run(int argc, char** argv) {

--- a/tests/src/MusicFadeTest/MusicFadeTest.cpp
+++ b/tests/src/MusicFadeTest/MusicFadeTest.cpp
@@ -8,6 +8,9 @@
 
 #include "MusicFadeTest/MusicFadeTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+
 namespace MusicFadeTest {
 
 bool MusicFadeTest::Run(int argc, char** argv) {

--- a/tests/src/MusicTest/MusicTest.cpp
+++ b/tests/src/MusicTest/MusicTest.cpp
@@ -8,6 +8,11 @@
 
 #include "MusicTest/MusicTest.hpp"
 
+#include <Core/ResourceManager.hpp>
+#include <Event/EventManager.hpp>
+
+#include <SFML/System.hpp>
+
 namespace MusicTest {
 
 bool MusicTest::Run(int argc, char** argv) {

--- a/tests/src/ParticlesTest/ParticlesTest.cpp
+++ b/tests/src/ParticlesTest/ParticlesTest.cpp
@@ -8,6 +8,13 @@
 
 #include "ParticlesTest/ParticlesTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
+#include <OgreParticleAffector.h>
+
 namespace ParticlesTest {
 
 bool ParticlesTest::Run(int argc, char** argv) {

--- a/tests/src/PhysicsSimpleTest/PhysicsSimpleTest.cpp
+++ b/tests/src/PhysicsSimpleTest/PhysicsSimpleTest.cpp
@@ -8,6 +8,11 @@
 
 #include "PhysicsSimpleTest/PhysicsSimpleTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace PhysicsSimpleTest {
 
 bool PhysicsSimpleTest::Run(int argc, char** argv) {

--- a/tests/src/PhysicsStressTest/PhysicsStressTest.cpp
+++ b/tests/src/PhysicsStressTest/PhysicsStressTest.cpp
@@ -8,6 +8,11 @@
 
 #include "PhysicsStressTest/PhysicsStressTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace PhysicsStressTest {
 
 bool PhysicsStressTest::Run(int argc, char** argv) {

--- a/tests/src/PrimitivesTest/PrimitivesTest.cpp
+++ b/tests/src/PrimitivesTest/PrimitivesTest.cpp
@@ -8,6 +8,11 @@
 
 #include "PrimitivesTest/PrimitivesTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace PrimitivesTest {
 
 bool PrimitivesTest::Run(int argc, char** argv) {

--- a/tests/src/ResourceManagerTest/ResourceManagerTest.cpp
+++ b/tests/src/ResourceManagerTest/ResourceManagerTest.cpp
@@ -8,6 +8,8 @@
 
 #include "ResourceManagerTest/ResourceManagerTest.hpp"
 
+#include <Core/ResourceManager.hpp>
+
 namespace ResourceManagerTest {
 
 bool ResourceManagerTest::Run(int argc, char** argv) {

--- a/tests/src/ScriptComponentTest/ScriptComponentTest.cpp
+++ b/tests/src/ScriptComponentTest/ScriptComponentTest.cpp
@@ -8,6 +8,12 @@
 
 #include "ScriptComponentTest/ScriptComponentTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Logic/ScriptManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace ScriptComponentTest {
 
 bool ScriptComponentTest::Run(int argc, char** argv) {

--- a/tests/src/ScriptingTest/ScriptingTest.cpp
+++ b/tests/src/ScriptingTest/ScriptingTest.cpp
@@ -10,6 +10,8 @@
 
 #include <Utils/Utils.hpp>
 
+#include <SFML/System.hpp>
+
 namespace ScriptingTest {
 
 bool ScriptingTest::Run(int argc, char** argv) {

--- a/tests/src/ShadowsTest/ShadowsTest.cpp
+++ b/tests/src/ShadowsTest/ShadowsTest.cpp
@@ -8,6 +8,11 @@
 
 #include "ShadowsTest/ShadowsTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+
 namespace ShadowsTest {
 
 bool ShadowsTest::Run(int argc, char** argv) {

--- a/tests/src/SignalsTest/SignalsTest.hpp
+++ b/tests/src/SignalsTest/SignalsTest.hpp
@@ -12,6 +12,7 @@
 #include "Test.hpp"
 
 #include <Core/Root.hpp>
+#include <Scene/Component.hpp>
 
 #include <QObject>
 

--- a/tests/src/SoundTest/SoundTest.cpp
+++ b/tests/src/SoundTest/SoundTest.cpp
@@ -9,6 +9,10 @@
 #include "SoundTest/SoundTest.hpp"
 
 #include <Utils/Utils.hpp>
+#include <Event/EventManager.hpp>
+
+#include <SFML/Audio.hpp>
+#include <SFML/System.hpp>
 
 namespace SoundTest {
 

--- a/tests/src/StatesTest/StatesTest.cpp
+++ b/tests/src/StatesTest/StatesTest.cpp
@@ -8,6 +8,12 @@
 
 #include "StatesTest/StatesTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+#include <Input/InputManager.hpp>
+
 namespace StatesTest {
 
 bool StatesTest::Run(int argc, char** argv) {

--- a/tests/src/TerrainTest/TerrainTest.cpp
+++ b/tests/src/TerrainTest/TerrainTest.cpp
@@ -8,8 +8,12 @@
 
 #include "TerrainTest/TerrainTest.hpp"
 
-#include <Logic/SimplePlayerComponent.hpp>
 #include <Utils/Logger.hpp>
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+#include <Graphics/CameraComponent.hpp>
+#include <Graphics/TerrainManager.hpp>
 
 namespace TerrainTest {
 
@@ -45,8 +49,6 @@ void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
 }
 
 void Main::OnInitialize() {
-    dt::InputManager::Get()->SetJailInput(false);
-
     dt::Scene* scene = AddScene(new dt::Scene("testscene"));
 
     dt::ResourceManager::Get()->AddResourceLocation("sinbad.zip","Zip", true);
@@ -57,7 +59,6 @@ void Main::OnInitialize() {
     camnode->SetPosition(Ogre::Vector3(0, 350, 150));
     dt::CameraComponent* cam = camnode->AddComponent(new dt::CameraComponent("cam"));
     cam->LookAt(Ogre::Vector3(0, 300, 0));
-    //camnode->AddComponent(new dt::SimplePlayerComponent("player"));
 
     dt::Node* lightnode = scene->AddChildNode(new dt::Node("lightnode"));
     dt::LightComponent* light = lightnode->AddComponent(new dt::LightComponent("light"));

--- a/tests/src/TextTest/TextTest.cpp
+++ b/tests/src/TextTest/TextTest.cpp
@@ -8,6 +8,10 @@
 
 #include "TextTest/TextTest.hpp"
 
+#include <Event/BeginFrameEvent.hpp>
+#include <Scene/StateManager.hpp>
+#include <Core/ResourceManager.hpp>
+
 namespace TextTest {
 
 bool TextTest::Run(int argc, char** argv) {

--- a/tests/src/TimerTest/TimerTest.cpp
+++ b/tests/src/TimerTest/TimerTest.cpp
@@ -21,6 +21,7 @@
 #include <Scene/State.hpp>
 #include <Utils/Timer.hpp>
 #include <Utils/Utils.hpp>
+#include <Scene/StateManager.hpp>
 
 #include <QObject>
 


### PR DESCRIPTION
Root now uses forward-declarations for all managers. This should speed up compilation-time when changing a header of a manager.
