### PR TITLE
all text events changed to enums

### DIFF
--- a/engine/src/Audio/MusicComponent.cpp
+++ b/engine/src/Audio/MusicComponent.cpp
@@ -27,7 +27,7 @@ MusicComponent::MusicComponent(const QString& music_file, const QString& name)
 }
 
 void MusicComponent::HandleEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "DT_MUSICCONTROLEVENT") {
+    if(e->GetType() == DT_MUSICCONTROLEVENT) {
         std::shared_ptr<MusicControlEvent> m = std::dynamic_pointer_cast<MusicControlEvent>(e);
         if(m->GetAction() == MusicControlEvent::PAUSE) {
             PauseMusic();

--- a/engine/src/Audio/MusicControlEvent.cpp
+++ b/engine/src/Audio/MusicControlEvent.cpp
@@ -13,8 +13,8 @@ namespace dt {
 MusicControlEvent::MusicControlEvent(MusicControlEvent::Action action)
     : mAction(action) {}
 
-const QString MusicControlEvent::GetType() const {
-   return "DT_MUSICCONTROLEVENT";
+uint32_t MusicControlEvent::GetType() const {
+   return DT_MUSICCONTROLEVENT;
 }
 
 std::shared_ptr<Event> MusicControlEvent::Clone() const {

--- a/engine/src/Audio/MusicControlEvent.hpp
+++ b/engine/src/Audio/MusicControlEvent.hpp
@@ -36,7 +36,7 @@ public:
      * @param action The action to perform with all sounds.
      */
     MusicControlEvent(Action action);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 
     /**

--- a/engine/src/Audio/SoundComponent.cpp
+++ b/engine/src/Audio/SoundComponent.cpp
@@ -24,7 +24,7 @@ SoundComponent::SoundComponent(const QString& sound_file, const QString& name)
 }
 
 void SoundComponent::HandleEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "DT_SOUNDSCONTROLEVENT") {
+    if(e->GetType() == DT_SOUNDSCONTROLEVENT) {
         std::shared_ptr<SoundsControlEvent> s = \
             std::dynamic_pointer_cast<SoundsControlEvent>(e);
 

--- a/engine/src/Audio/SoundsControlEvent.cpp
+++ b/engine/src/Audio/SoundsControlEvent.cpp
@@ -13,8 +13,8 @@ namespace dt {
 SoundsControlEvent::SoundsControlEvent(SoundsControlEvent::Action action)
     : mAction(action) {}
 
-const QString SoundsControlEvent::GetType() const {
-   return "DT_SOUNDSCONTROLEVENT";
+uint32_t SoundsControlEvent::GetType() const {
+   return DT_SOUNDSCONTROLEVENT;
 }
 
 std::shared_ptr<Event> SoundsControlEvent::Clone() const {

--- a/engine/src/Audio/SoundsControlEvent.hpp
+++ b/engine/src/Audio/SoundsControlEvent.hpp
@@ -38,7 +38,7 @@ public:
      * @param action The action to perform with all sounds.
      */
     SoundsControlEvent(Action action);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 
     /**

--- a/engine/src/Event/BeginFrameEvent.cpp
+++ b/engine/src/Event/BeginFrameEvent.cpp
@@ -13,8 +13,8 @@ namespace dt {
 BeginFrameEvent::BeginFrameEvent(double frame_time)
     : mFrameTime(frame_time) {}
 
-const QString BeginFrameEvent::GetType() const {
-    return "DT_BEGINFRAMEEVENT";
+uint32_t BeginFrameEvent::GetType() const {
+    return DT_BEGINFRAMEEVENT;
 }
 
 std::shared_ptr<Event> BeginFrameEvent::Clone() const {

--- a/engine/src/Event/BeginFrameEvent.hpp
+++ b/engine/src/Event/BeginFrameEvent.hpp
@@ -29,7 +29,7 @@ public:
       * @param frame_time The time delta of the current frame.
       */
     BeginFrameEvent(double frame_time);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 
 

--- a/engine/src/Event/Event.cpp
+++ b/engine/src/Event/Event.cpp
@@ -19,10 +19,6 @@ bool Event::IsNetworkEvent() const {
     return false;
 }
 
-uint32_t Event::GetTypeID() const {
-    return StringManager::Get()->GetId(GetType());
-}
-
 void Event::Cancel() {
     mIsCanceled = true;
 }

--- a/engine/src/Event/Event.hpp
+++ b/engine/src/Event/Event.hpp
@@ -11,12 +11,27 @@
 
 #include <Config.hpp>
 
-#include <QString>
+//#include <QString>
 
 #include <cstdint>
 #include <memory>
 
 namespace dt {
+
+enum EventType : uint32_t{
+    DT_WINDOWCLOSEDEVENT = 0,
+    DT_BEGINFRAMEEVENT = 1,
+    DT_MOUSEEVENT = 2,
+    DT_KEYBOARDEVENT = 3,
+    DT_TIMERTICKEVENT = 4,
+    DT_TRIGGEREVENT = 5,
+    DT_MESSAGEEVENT = 6,
+    DT_SOUNDSCONTROLEVENT = 7,
+    DT_MUSICCONTROLEVENT = 8,
+    DT_PINGEVENT = 9,
+    DT_HANDSHAKEEVENT = 10,
+    DT_GOODBYEEVENT = 11
+};
 
 /**
   * Abstract base class for any Event that is passed through the Event system.
@@ -31,12 +46,6 @@ public:
     Event();
 
     /**
-      * Returns the type string of the Event for serialization / identification for typecasts.
-      * @returns The type string of the Event.
-      */
-    virtual const QString GetType() const = 0;
-
-    /**
       * Returns whether this Event is being sent over network. This is only applicable for Events being inherited from NetworkEvent.
       * @returns Whether this Event is being sent over network. (True for any Event inherited from NetworkEvent.)
       */
@@ -49,12 +58,10 @@ public:
     virtual std::shared_ptr<Event> Clone() const = 0;
 
     /**
-      * Returns the type ID of the Event. The ID is got from the StringManager using the type string returned by GetType().
-      * @see Event::GetType()
-      * @see StringManager
+      * Returns the type ID of the Event as specified in the enumeration in either EventType or project files.
       * @returns The type ID of the Event.
       */
-    uint32_t GetTypeID() const;
+    virtual uint32_t GetType() const = 0;
 
     /**
       * Cancels the execution of the event.

--- a/engine/src/Event/EventManager.cpp
+++ b/engine/src/Event/EventManager.cpp
@@ -102,6 +102,18 @@ BindingsManager* EventManager::GetBindingsManager() {
     return &mBindingsManager;
 }
 
+void EventManager::RegEventType(const QString& name, uint32_t id) {
+    if (id < 35536) {
+        Logger::Get().Warning("Failed registering event " + name + " at " + id + " because those id's are only used in Engine Events found in Event.hpp");
+    }
+    else if (mEventIds[id] != "") {
+        Logger::Get().Warning("Failed registering event " + name + " at " + id + " because that id is already taken by " + mEventIds[id]);
+    }
+    else {
+        mEventIds[id] = name;
+        Logger::Get().Debug("Succeeded in registering event " + name + " at " + id);
+    }
+}
 
 void EventManager::_LockListeners() {
     mListenersLocked = true;

--- a/engine/src/Event/EventManager.cpp
+++ b/engine/src/Event/EventManager.cpp
@@ -103,15 +103,17 @@ BindingsManager* EventManager::GetBindingsManager() {
 }
 
 void EventManager::RegEventType(const QString& name, uint32_t id) {
-    if (id < 35536) {
-        Logger::Get().Warning("Failed registering event " + name + " at " + id + " because those id's are only used in Engine Events found in Event.hpp");
+    char id_str[10];
+    sprintf(id_str, "%d", id);
+    if (id < 65536) {
+        Logger::Get().Warning("Failed registering event " + name + " at " + id_str + " because those id's are only used in Engine Events found in Event.hpp");
     }
-    else if (mEventIds[id] != "") {
-        Logger::Get().Warning("Failed registering event " + name + " at " + id + " because that id is already taken by " + mEventIds[id]);
+    else if (mEventIds[id] != "" && mEventIds[id] != name) {
+        Logger::Get().Warning("Failed registering event " + name + " at " + id_str + " because that id is already taken by " + mEventIds[id]);
     }
-    else {
+    else if (mEventIds[id] != name) {
         mEventIds[id] = name;
-        Logger::Get().Debug("Succeeded in registering event " + name + " at " + id);
+        Logger::Get().Info("Succeeded in registering event " + name + " at " + id_str);
     }
 }
 

--- a/engine/src/Event/EventManager.hpp
+++ b/engine/src/Event/EventManager.hpp
@@ -85,6 +85,14 @@ public:
       */
     BindingsManager* GetBindingsManager();
 
+    /**
+      * Registers a new string with a generated Id for use in debug to see which id's are taken.
+      * Id's < 65536 are engine events.
+      * @param name The string to register. id The Id to register.
+      * @returns The new Id.
+      */
+    void RegEventType(const QString& name, uint32_t id);
+
 private:
     /**
       * Locks the list of listener.
@@ -102,6 +110,9 @@ private:
     bool mListenersLocked;                              //!< Whether the list of listener is locked (due to being looped over etc.)
     std::vector<EventListener*> mListenerAddQueue;      //!< The queue of listeners to add when the list is unlocked.
     std::vector<EventListener*> mListenerRemoveQueue;   //!< The queue of listeners to remove when the list is unlocked.
+
+
+    std::map<uint32_t, QString> mEventIds;   //!< The relation map between Event Type Ids/strings.
 };
 
 }

--- a/engine/src/Event/MessageEvent.cpp
+++ b/engine/src/Event/MessageEvent.cpp
@@ -13,8 +13,8 @@ namespace dt {
 MessageEvent::MessageEvent(const QString& message)
     : mMessage(message) {}
 
-const QString MessageEvent::GetType() const {
-    return "DT_MESSAGEEVENT";
+uint32_t MessageEvent::GetType() const {
+    return DT_MESSAGEEVENT;
 }
 
 const QString& MessageEvent::GetMessageText() const {

--- a/engine/src/Event/MessageEvent.hpp
+++ b/engine/src/Event/MessageEvent.hpp
@@ -27,7 +27,7 @@ public:
       * @param message The message for this Event.
       */
     MessageEvent(const QString& message);
-    const QString GetType() const;
+    uint32_t GetType() const;
 
     /**
       * Returns the message of this Event.

--- a/engine/src/Event/SimpleEventBinding.cpp
+++ b/engine/src/Event/SimpleEventBinding.cpp
@@ -10,7 +10,7 @@
 
 namespace dt {
 
-SimpleEventBinding::SimpleEventBinding(Event* target, const QString& trigger_type)
+SimpleEventBinding::SimpleEventBinding(Event* target, uint32_t trigger_type)
     : EventBinding(target),
       mTriggerType(trigger_type) {}
 

--- a/engine/src/Event/SimpleEventBinding.hpp
+++ b/engine/src/Event/SimpleEventBinding.hpp
@@ -31,11 +31,11 @@ public:
       * @param target The event that is being triggered.
       * @param trigger_type The type of the event that triggers this binding.
       */
-    SimpleEventBinding(Event* target, const QString& trigger_type);
+    SimpleEventBinding(Event* target, uint32_t trigger_type);
     bool MatchesEvent(std::shared_ptr<Event> e);
 
 private:
-    QString mTriggerType;   //!< The type of the event that triggers this binding.
+    uint32_t mTriggerType;   //!< The type of the event that triggers this binding.
 
 };
 

--- a/engine/src/Graphics/WindowClosedEvent.cpp
+++ b/engine/src/Graphics/WindowClosedEvent.cpp
@@ -12,8 +12,8 @@ namespace dt {
 
 WindowClosedEvent::WindowClosedEvent() {}
 
-const QString WindowClosedEvent::GetType() const {
-    return "DT_WINDOWCLOSEDEVENT";
+uint32_t WindowClosedEvent::GetType() const {
+    return DT_WINDOWCLOSEDEVENT;
 }
 
 std::shared_ptr<Event> WindowClosedEvent::Clone() const {

--- a/engine/src/Graphics/WindowClosedEvent.hpp
+++ b/engine/src/Graphics/WindowClosedEvent.hpp
@@ -28,7 +28,7 @@ public:
      * Default constructor.
      */
     WindowClosedEvent();
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 };
 

--- a/engine/src/Gui/GuiManager.cpp
+++ b/engine/src/Gui/GuiManager.cpp
@@ -81,7 +81,7 @@ void GuiManager::HandleEvent(std::shared_ptr<Event> e) {
         return;
     }
 
-    if(e->GetType() == "DT_MOUSEEVENT") {
+    if(e->GetType() == EventType::DT_MOUSEEVENT) {
         std::shared_ptr<MouseEvent> m = std::dynamic_pointer_cast<MouseEvent>(e);
         if(m->GetAction() ==  MouseEvent::MOVED) {
             mygui_inputmgr->injectMouseMove(m->GetMouseState().X.abs,
@@ -96,7 +96,7 @@ void GuiManager::HandleEvent(std::shared_ptr<Event> e) {
                                                m->GetMouseState().Y.abs,
                                         MyGUI::MouseButton::Enum(m->GetButton()));
         }
-    } else if(e->GetType() == "DT_KEYBOARDEVENT") {
+    } else if(e->GetType() == EventType::DT_KEYBOARDEVENT) {
         std::shared_ptr<KeyboardEvent> k = std::dynamic_pointer_cast<KeyboardEvent>(e);
         if(k->GetAction() == KeyboardEvent::PRESSED) {
             mygui_inputmgr->injectKeyPress(MyGUI::KeyCode::Enum(k->GetCode()),

--- a/engine/src/Input/KeyboardEvent.cpp
+++ b/engine/src/Input/KeyboardEvent.cpp
@@ -15,8 +15,8 @@ KeyboardEvent::KeyboardEvent(KeyboardEvent::Action action, OIS::KeyCode code, ch
       mAction(action),
       mText(text) {}
 
-const QString KeyboardEvent::GetType() const {
-    return "DT_KEYBOARDEVENT";
+uint32_t KeyboardEvent::GetType() const {
+    return DT_KEYBOARDEVENT;
 }
 
 std::shared_ptr<Event> KeyboardEvent::Clone() const {

--- a/engine/src/Input/KeyboardEvent.hpp
+++ b/engine/src/Input/KeyboardEvent.hpp
@@ -41,7 +41,7 @@ public:
       * @param text The character the pressed key is assigned to.
       */
     KeyboardEvent(Action action, OIS::KeyCode code, char text);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 
     /**

--- a/engine/src/Input/KeyboardEventBinding.cpp
+++ b/engine/src/Input/KeyboardEventBinding.cpp
@@ -17,7 +17,7 @@ KeyboardBinding::KeyboardBinding(Event* target, OIS::KeyCode key_code)
       mKeyCode(key_code) {}
 
 bool KeyboardBinding::MatchesEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "DT_KEYBOARDEVENT") {
+    if(e->GetType() == DT_KEYBOARDEVENT) {
         std::shared_ptr<KeyboardEvent> k = std::dynamic_pointer_cast<KeyboardEvent>(e);
         return k->GetCode() == mKeyCode;
     }

--- a/engine/src/Input/MouseEvent.cpp
+++ b/engine/src/Input/MouseEvent.cpp
@@ -15,8 +15,8 @@ MouseEvent::MouseEvent(MouseEvent::Action action, OIS::MouseState state, OIS::Mo
       mAction(action),
       mButton(button) {}
 
-const QString MouseEvent::GetType() const {
-    return "DT_MOUSEEVENT";
+uint32_t MouseEvent::GetType() const {
+    return DT_MOUSEEVENT;
 }
 
 std::shared_ptr<Event> MouseEvent::Clone() const {

--- a/engine/src/Input/MouseEvent.hpp
+++ b/engine/src/Input/MouseEvent.hpp
@@ -42,7 +42,7 @@ public:
       * @param button The mouse button that caused the event. For MOVED, this will always be OIS::MB_Left.
       */
     MouseEvent(Action action, OIS::MouseState state, OIS::MouseButtonID button = OIS::MB_Left);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 
     /**

--- a/engine/src/Logic/SimplePlayerComponent.cpp
+++ b/engine/src/Logic/SimplePlayerComponent.cpp
@@ -30,7 +30,7 @@ void SimplePlayerComponent::HandleEvent(std::shared_ptr<Event> e) {
     if(!IsEnabled())
         return;
 
-    if(mMouseEnabled && e->GetType() == "DT_MOUSEEVENT") {
+    if(mMouseEnabled && e->GetType() == DT_MOUSEEVENT) {
         std::shared_ptr<MouseEvent> m = std::dynamic_pointer_cast<MouseEvent>(e);
         if(m->GetAction() == MouseEvent::MOVED) {
             float factor = mMouseSensitivity * -0.01;

--- a/engine/src/Logic/TriggerComponent.cpp
+++ b/engine/src/Logic/TriggerComponent.cpp
@@ -15,7 +15,7 @@ TriggerComponent::TriggerComponent(const QString& name)
 }
 
 void TriggerComponent::HandleEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "trigger") {
+    if(e->GetType() == DT_TRIGGEREVENT) {
 
     }
 }

--- a/engine/src/Network/ConnectionsManager.cpp
+++ b/engine/src/Network/ConnectionsManager.cpp
@@ -145,14 +145,14 @@ double ConnectionsManager::GetTimeout() {
 }
 
 void ConnectionsManager::HandleEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "DT_TIMERTICKEVENT") {
+    if(e->GetType() == DT_TIMERTICKEVENT) {
         std::shared_ptr<TimerTickEvent> t = std::dynamic_pointer_cast<TimerTickEvent>(e);
         if(t->GetMessageText() == "DT_SEND_PING" && t->GetInterval() == mPingInterval) {
             // this is our timer
             _Ping();
             _CheckTimeouts();
         }
-    } else if(e->GetType() == "DT_PINGEVENT") {
+    } else if(e->GetType() == DT_PINGEVENT) {
         std::shared_ptr<PingEvent> p = std::dynamic_pointer_cast<PingEvent>(e);
         if(p->IsLocalEvent()) {
             // yes, we received this from the network

--- a/engine/src/Network/GoodbyeEvent.cpp
+++ b/engine/src/Network/GoodbyeEvent.cpp
@@ -13,8 +13,8 @@ namespace dt {
 GoodbyeEvent::GoodbyeEvent(const QString& reason)
     : mReason(reason) {}
 
-const QString GoodbyeEvent::GetType() const {
-    return "DT_GOODBYEEVENT";
+uint32_t GoodbyeEvent::GetType() const {
+    return DT_GOODBYEEVENT;
 }
 
 std::shared_ptr<Event> GoodbyeEvent::Clone() const {

--- a/engine/src/Network/GoodbyeEvent.hpp
+++ b/engine/src/Network/GoodbyeEvent.hpp
@@ -31,7 +31,7 @@ public:
       */
     GoodbyeEvent(const QString& reason = "");
 
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
     void Serialize(IOPacket& p);
 

--- a/engine/src/Network/HandshakeEvent.cpp
+++ b/engine/src/Network/HandshakeEvent.cpp
@@ -12,8 +12,8 @@ namespace dt {
 
 HandshakeEvent::HandshakeEvent() {}
 
-const QString HandshakeEvent::GetType() const {
-    return "DT_HANDSHAKEEVENT";
+uint32_t HandshakeEvent::GetType() const {
+    return DT_HANDSHAKEEVENT;
 }
 
 std::shared_ptr<Event> HandshakeEvent::Clone() const {

--- a/engine/src/Network/HandshakeEvent.hpp
+++ b/engine/src/Network/HandshakeEvent.hpp
@@ -27,7 +27,7 @@ public:
       * Default constructor.
       */
     HandshakeEvent();
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
     void Serialize(IOPacket& p);
 };

--- a/engine/src/Network/NetworkEvent.hpp
+++ b/engine/src/Network/NetworkEvent.hpp
@@ -31,7 +31,7 @@ public:
       * Default constructor.
       */
     NetworkEvent();
-    virtual const QString GetType() const = 0;
+    virtual uint32_t GetType() const = 0;
     bool IsNetworkEvent() const;
 
     /**

--- a/engine/src/Network/NetworkManager.cpp
+++ b/engine/src/Network/NetworkManager.cpp
@@ -148,14 +148,14 @@ void NetworkManager::HandleEvent(std::shared_ptr<Event> e) {
         }
     }
 
-    if(e->GetType() == "DT_HANDSHAKEEVENT") {
+    if(e->GetType() == DT_HANDSHAKEEVENT) {
         // new client connected / server replied
         std::shared_ptr<HandshakeEvent> h = \
             std::dynamic_pointer_cast<HandshakeEvent>(e);
         if(h->GetSenderID() != 0) {
 
         }
-    } else if(e->GetType() == "DT_GOODBYEEVENT") {
+    } else if(e->GetType() == DT_GOODBYEEVENT) {
         // client sent a godbye event / server will disconnect the client
         std::shared_ptr<GoodbyeEvent> g = \
             std::dynamic_pointer_cast<GoodbyeEvent>(e);
@@ -171,13 +171,11 @@ EventListener::Priority NetworkManager::GetEventPriority() const {
 
 void NetworkManager::RegisterNetworkEventPrototype(std::shared_ptr<NetworkEvent> event) {
     mNetworkEventPrototypes.push_back(event);
-    // register the ID (if not already happened)
-    StringManager::Get()->Add(event->GetType());
 }
 
 std::shared_ptr<NetworkEvent> NetworkManager::CreatePrototypeInstance(uint32_t type_id) {
     for(auto iter = mNetworkEventPrototypes.begin(); iter != mNetworkEventPrototypes.end(); ++iter) {
-        if((*iter)->GetTypeID() == type_id) {
+        if((*iter)->GetType() == type_id) {
             return std::dynamic_pointer_cast<NetworkEvent>((*iter)->Clone());
         }
     }
@@ -191,7 +189,7 @@ ConnectionsManager* NetworkManager::GetConnectionsManager() {
 void NetworkManager::_SendEvent(std::shared_ptr<NetworkEvent> event) {
     // create packet
     sf::Packet p;
-    p << event->GetTypeID();
+    p << event->GetType();
     IOPacket packet(&p, IOPacket::MODE_SEND);
     event->Serialize(packet);
 

--- a/engine/src/Network/PingEvent.cpp
+++ b/engine/src/Network/PingEvent.cpp
@@ -14,8 +14,8 @@ PingEvent::PingEvent(double timestamp, bool is_reply)
     : mIsReply(is_reply),
       mTimestamp(timestamp) {}
 
-const QString PingEvent::GetType() const {
-    return "DT_PINGEVENT";
+uint32_t PingEvent::GetType() const {
+    return DT_PINGEVENT;
 }
 
 std::shared_ptr<Event> PingEvent::Clone() const {

--- a/engine/src/Network/PingEvent.hpp
+++ b/engine/src/Network/PingEvent.hpp
@@ -31,7 +31,7 @@ public:
       * @param is_reply Whether this ping is a reply.
       */
     PingEvent(double timestamp, bool is_reply = false);
-    const QString GetType() const;
+    uint32_t GetType() const;
 
     std::shared_ptr<Event> Clone() const;
     void Serialize(IOPacket& p);

--- a/engine/src/Physics/PhysicsManager.cpp
+++ b/engine/src/Physics/PhysicsManager.cpp
@@ -29,7 +29,7 @@ void PhysicsManager::Deinitialize() {
 }
 
 void PhysicsManager::HandleEvent(std::shared_ptr<Event> e) {
-   if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+   if(e->GetType() == DT_BEGINFRAMEEVENT) {
        double time_diff = std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
 
        // step all worlds

--- a/engine/src/Scene/Game.cpp
+++ b/engine/src/Scene/Game.cpp
@@ -26,7 +26,7 @@ Game::Game()
       mIsRunning(false) {}
 
 void Game::HandleEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "DT_WINDOWCLOSEDEVENT") {
+    if(e->GetType() == DT_WINDOWCLOSEDEVENT) {
         Logger::Get().Debug("The closed window triggered a game shutdown.");
         RequestShutdown();
     }

--- a/engine/src/Scene/Scene.cpp
+++ b/engine/src/Scene/Scene.cpp
@@ -41,7 +41,7 @@ bool Scene::_IsScene() {
 }
 
 void Scene::HandleEvent(std::shared_ptr<Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == DT_BEGINFRAMEEVENT) {
         OnUpdate((std::dynamic_pointer_cast<BeginFrameEvent>(e))->GetFrameTime());
     }
 }

--- a/engine/src/Utils/Timer.cpp
+++ b/engine/src/Utils/Timer.cpp
@@ -29,7 +29,7 @@ Timer::Timer(const QString& message, double interval, bool repeat, bool threaded
 void Timer::HandleEvent(std::shared_ptr<Event> e) {
     // for event mode
 
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == DT_BEGINFRAMEEVENT) {
         // every frame
         std::shared_ptr<BeginFrameEvent> b = std::dynamic_pointer_cast<BeginFrameEvent>(e);
 

--- a/engine/src/Utils/TimerTickEvent.cpp
+++ b/engine/src/Utils/TimerTickEvent.cpp
@@ -14,8 +14,8 @@ TimerTickEvent::TimerTickEvent(const QString& message, double interval)
     : MessageEvent(message),
       mInterval(interval) {}
 
-const QString TimerTickEvent::GetType() const {
-    return "DT_TIMERTICKEVENT";
+uint32_t TimerTickEvent::GetType() const {
+    return DT_TIMERTICKEVENT;
 }
 
 std::shared_ptr<Event> TimerTickEvent::Clone() const {

--- a/engine/src/Utils/TimerTickEvent.hpp
+++ b/engine/src/Utils/TimerTickEvent.hpp
@@ -31,7 +31,7 @@ public:
       * @param interval The interval of the timer.
       */
     TimerTickEvent(const QString& message, double interval);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<Event> Clone() const;
 
     /**

--- a/samples/chat/src/client/Client.cpp
+++ b/samples/chat/src/client/Client.cpp
@@ -23,6 +23,7 @@ Client::Client() {
 
 void Client::OnInitialize() {
     dt::EventManager::Get()->AddListener(this);
+    dt::EventManager::Get()->RegEventType("chatMessageEvent", 65536);
     dt::Logger::Get().GetStream("debug")->SetDisabled(true);
     dt::Logger::Get().GetStream("info")->SetDisabled(true);
 

--- a/samples/chat/src/client/Client.cpp
+++ b/samples/chat/src/client/Client.cpp
@@ -37,7 +37,7 @@ void Client::OnInitialize() {
 }
 
 void Client::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "CHATMESSAGEEVENT") {
+    if(e->GetType() == chatMessageEvent) {
         std::shared_ptr<ChatMessageEvent> c = std::dynamic_pointer_cast<ChatMessageEvent>(e);
         if(c->IsLocalEvent()) { // we just received this
             std::cout << std::endl << "<" << dt::Utils::ToStdString(c->GetSenderNick()) << "> " << dt::Utils::ToStdString(c->GetMessageText()) << std::endl;

--- a/samples/chat/src/common/ChatMessageEvent.cpp
+++ b/samples/chat/src/common/ChatMessageEvent.cpp
@@ -13,8 +13,8 @@ ChatMessageEvent::ChatMessageEvent(const QString& message, const QString& sender
     mSenderNick = sender;
 }
 
-const QString ChatMessageEvent::GetType() const {
-    return "CHATMESSAGEEVENT";
+uint32_t ChatMessageEvent::GetType() const {
+    return chatMessageEvent;
 }
 
 std::shared_ptr<dt::Event> ChatMessageEvent::Clone() const {

--- a/samples/chat/src/common/ChatMessageEvent.hpp
+++ b/samples/chat/src/common/ChatMessageEvent.hpp
@@ -12,11 +12,6 @@
 #include <Network/NetworkEvent.hpp>
 #include <Event/MessageEvent.hpp>
 
-#ifdef DUCTTAPE_ENGINE_DEBUG
-#include <Event/EventManager.hpp>
-dt::EventManager::Get()->RegEventType("chatMessageEvent", 65536);
-#endif
-
 enum ChatEventType : uint32_t {
     chatMessageEvent = 65536
 };

--- a/samples/chat/src/common/ChatMessageEvent.hpp
+++ b/samples/chat/src/common/ChatMessageEvent.hpp
@@ -12,10 +12,19 @@
 #include <Network/NetworkEvent.hpp>
 #include <Event/MessageEvent.hpp>
 
+#ifdef DUCTTAPE_ENGINE_DEBUG
+#include <Event/EventManager.hpp>
+dt::EventManager::Get()->RegEventType("chatMessageEvent", 65536);
+#endif
+
+enum ChatEventType : uint32_t {
+    chatMessageEvent = 65536
+};
+
 class ChatMessageEvent : public dt::NetworkEvent, public dt::MessageEvent {
 public:
     ChatMessageEvent(const QString& message, const QString& sender);
-    const QString GetType() const;
+    uint32_t GetType() const;
 
     std::shared_ptr<dt::Event> Clone() const;
     void Serialize(dt::IOPacket& p);

--- a/samples/chat/src/server/Server.cpp
+++ b/samples/chat/src/server/Server.cpp
@@ -29,7 +29,7 @@ void Server::HandleEvent(std::shared_ptr<dt::Event> e) {
     // This is quite useful for debugging purposes.
     //dt::Logger::Get().Info("There are " + boost::lexical_cast<QString>(dt::ConnectionsManager::Get()->GetConnectionCount()) + " connections active.");
 
-    if(e->GetType() == "CHATMESSAGEEVENT") {
+    if(e->GetType() == chatMessageEvent) {
         std::shared_ptr<ChatMessageEvent> c = std::dynamic_pointer_cast<ChatMessageEvent>(e);
 
         if(c->IsLocalEvent()) { // we just received this
@@ -47,7 +47,7 @@ void Server::HandleEvent(std::shared_ptr<dt::Event> e) {
                 InjectEvent(std::make_shared<ChatMessageEvent>(c->GetMessageText(), c->GetSenderNick()));
         }
 
-    } else if(e->GetType() == "DT_GOODBYEEVENT") {
+    } else if(e->GetType() == dt::DT_GOODBYEEVENT) {
         dt::Logger::Get().Info("Client disconnected: " + std::dynamic_pointer_cast<dt::GoodbyeEvent>(e)->GetReason());
     }
 }

--- a/samples/simplepong/src/main.cpp
+++ b/samples/simplepong/src/main.cpp
@@ -45,7 +45,7 @@ public:
     }
 
     void HandleEvent(std::shared_ptr<dt::Event> e) {
-        if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+        if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
             double frame_time = std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
 
             mBallSpeed *= 1.0 + (frame_time * 0.05);

--- a/tests/src/CamerasTest/CamerasTest.cpp
+++ b/tests/src/CamerasTest/CamerasTest.cpp
@@ -26,7 +26,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 3.0) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/DisplayTest/DisplayTest.cpp
+++ b/tests/src/DisplayTest/DisplayTest.cpp
@@ -31,7 +31,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2.5) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/EventBindingsTest/EventBindingsTest.cpp
+++ b/tests/src/EventBindingsTest/EventBindingsTest.cpp
@@ -19,6 +19,8 @@ bool EventBindingsTest::Run(int argc, char** argv) {
     root.Initialize(argc, argv);
 
     TestEventListener listener;
+    root.GetEventManager()->RegEventType("testTriggerEvent", 65536);
+    root.GetEventManager()->RegEventType("testBoundEvent", 65537);
     root.GetEventManager()->AddListener(&listener);
 
     dt::BindingsManager::Get()->Bind(std::make_shared<dt::SimpleEventBinding>(new TestBoundEvent(42), testTriggerEvent));
@@ -72,9 +74,7 @@ std::shared_ptr<dt::Event> TestBoundEvent::Clone() const {
 ////////////////////////////////////////////////////////////////
 
 void TestEventListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-#ifdef DUCTTAPE_ENGINE_DEBUG
-    std::cout << "Received: " << dt::EventManager::Get->RegEventType(e->GetType()) << std::endl;
-#endif
+    std::cout << "Received: " << e->GetType() << std::endl;
     if(e->GetType() == testTriggerEvent) {
         mHasReceivedTriggerEvent = true;
     } else if(e->GetType() == testBoundEvent) {

--- a/tests/src/EventBindingsTest/EventBindingsTest.cpp
+++ b/tests/src/EventBindingsTest/EventBindingsTest.cpp
@@ -18,13 +18,10 @@ bool EventBindingsTest::Run(int argc, char** argv) {
     dt::Root& root = dt::Root::GetInstance();
     root.Initialize(argc, argv);
 
-    root.GetStringManager()->Add("testtriggerevent");
-    root.GetStringManager()->Add("testboundevent");
-
     TestEventListener listener;
     root.GetEventManager()->AddListener(&listener);
 
-    dt::BindingsManager::Get()->Bind(std::make_shared<dt::SimpleEventBinding>(new TestBoundEvent(42), "testtriggerevent"));
+    dt::BindingsManager::Get()->Bind(std::make_shared<dt::SimpleEventBinding>(new TestBoundEvent(42), testTriggerEvent));
 
     root.GetEventManager()->InjectEvent(std::make_shared<TestTriggerEvent>());
 
@@ -49,8 +46,8 @@ QString EventBindingsTest::GetTestName() {
 
 ////////////////////////////////////////////////////////////////
 
-const QString TestTriggerEvent::GetType() const  {
-    return "testtriggerevent";
+uint32_t TestTriggerEvent::GetType() const  {
+    return testTriggerEvent;
 }
 
 std::shared_ptr<dt::Event> TestTriggerEvent::Clone() const {
@@ -63,8 +60,8 @@ std::shared_ptr<dt::Event> TestTriggerEvent::Clone() const {
 TestBoundEvent::TestBoundEvent(int data)
     : mData(data) {}
 
-const QString TestBoundEvent::GetType() const  {
-    return "testboundevent";
+uint32_t TestBoundEvent::GetType() const  {
+    return testBoundEvent;
 }
 
 std::shared_ptr<dt::Event> TestBoundEvent::Clone() const {
@@ -75,10 +72,12 @@ std::shared_ptr<dt::Event> TestBoundEvent::Clone() const {
 ////////////////////////////////////////////////////////////////
 
 void TestEventListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-    std::cout << "Received: " << dt::Utils::ToStdString(e->GetType()) << std::endl;
-    if(e->GetType() == "testtriggerevent") {
+#ifdef DUCTTAPE_ENGINE_DEBUG
+    std::cout << "Received: " << dt::EventManager::Get->RegEventType(e->GetType()) << std::endl;
+#endif
+    if(e->GetType() == testTriggerEvent) {
         mHasReceivedTriggerEvent = true;
-    } else if(e->GetType() == "testboundevent") {
+    } else if(e->GetType() == testBoundEvent) {
         if(std::dynamic_pointer_cast<TestBoundEvent>(e)->mData == 42) {
             mHasReceivedBoundEvent = true;
         } else {

--- a/tests/src/EventBindingsTest/EventBindingsTest.hpp
+++ b/tests/src/EventBindingsTest/EventBindingsTest.hpp
@@ -21,6 +21,16 @@
 
 namespace EventBindingsTest {
 
+#ifdef DUCTTAPE_ENGINE_DEBUG
+EventManager::Get()->RegEventType("testTriggerEvent", 65536);
+EventManager::Get()->RegEventType("testBoundEvent", 65537);
+#endif
+
+enum TestEventType : uint32_t {
+    testTriggerEvent = 65536,
+    testBoundEvent = 65537
+};
+
 class EventBindingsTest : public Test {
     bool Run(int argc, char** argv);
     QString GetTestName();
@@ -30,7 +40,7 @@ class EventBindingsTest : public Test {
 
 class TestTriggerEvent : public dt::Event {
 public:
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<dt::Event> Clone() const;
 };
 
@@ -39,7 +49,7 @@ public:
 class TestBoundEvent : public dt::Event {
 public:
     TestBoundEvent(int data);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<dt::Event> Clone() const;
     int mData;
 };

--- a/tests/src/EventBindingsTest/EventBindingsTest.hpp
+++ b/tests/src/EventBindingsTest/EventBindingsTest.hpp
@@ -21,11 +21,6 @@
 
 namespace EventBindingsTest {
 
-#ifdef DUCTTAPE_ENGINE_DEBUG
-EventManager::Get()->RegEventType("testTriggerEvent", 65536);
-EventManager::Get()->RegEventType("testBoundEvent", 65537);
-#endif
-
 enum TestEventType : uint32_t {
     testTriggerEvent = 65536,
     testBoundEvent = 65537

--- a/tests/src/EventsTest/EventsTest.cpp
+++ b/tests/src/EventsTest/EventsTest.cpp
@@ -19,6 +19,9 @@ bool EventsTest::Run(int argc, char** argv) {
 
     TestEventListener listener;
 
+    root.GetEventManager()->RegEventType("cancelEvent", 65536);
+    root.GetEventManager()->RegEventType("testEvent", 65537);
+
     root.GetEventManager()->AddListener(&listener);
     root.GetEventManager()->InjectEvent(std::make_shared<TestEvent>());
 

--- a/tests/src/EventsTest/EventsTest.cpp
+++ b/tests/src/EventsTest/EventsTest.cpp
@@ -17,8 +17,6 @@ bool EventsTest::Run(int argc, char** argv) {
     dt::Root& root = dt::Root::GetInstance();
     root.Initialize(argc, argv);
 
-    root.GetStringManager()->Add("testevent");
-
     TestEventListener listener;
 
     root.GetEventManager()->AddListener(&listener);
@@ -55,8 +53,8 @@ QString EventsTest::GetTestName() {
 
 ////////////////////////////////////////////////////////////////
 
-const QString CancelEvent::GetType() const  {
-    return "cancelevent";
+uint32_t CancelEvent::GetType() const  {
+    return cancelEvent;
 }
 
 std::shared_ptr<dt::Event> CancelEvent::Clone() const {
@@ -67,7 +65,7 @@ std::shared_ptr<dt::Event> CancelEvent::Clone() const {
 ////////////////////////////////////////////////////////////////
 
 void CancelListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "cancelevent") {
+    if(e->GetType() == cancelEvent) {
         dt::Logger::Get().Info("CancelListener: Canceling event");
         e->Cancel();
     }
@@ -80,7 +78,7 @@ CancelListener::Priority CancelListener::GetEventPriority() const {
 ////////////////////////////////////////////////////////////////
 
 void NonCancelListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "cancelevent") {
+    if(e->GetType() == cancelEvent) {
         std::cerr << "Error: NonCancelListener should not receive a CancelEvent." << std::endl;
         exit(1);
     }
@@ -99,8 +97,8 @@ TestEvent::TestEvent() {
     anti_leak_payload.push_back(10);
 }
 
-const QString TestEvent::GetType() const  {
-    return "testevent";
+uint32_t TestEvent::GetType() const  {
+    return testEvent;
 }
 
 std::shared_ptr<dt::Event> TestEvent::Clone() const {
@@ -111,7 +109,7 @@ std::shared_ptr<dt::Event> TestEvent::Clone() const {
 ////////////////////////////////////////////////////////////////
 
 void TestEventListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "testevent") {
+    if(e->GetType() == testEvent) {
         mHasReceivedTestEvent = true;
     }
     mHasReceivedAnEvent = true;

--- a/tests/src/EventsTest/EventsTest.hpp
+++ b/tests/src/EventsTest/EventsTest.hpp
@@ -20,11 +20,6 @@
 
 namespace EventsTest {
 
-#ifdef DUCTTAPE_ENGINE_DEBUG
-EventManager::Get()->RegEventType("cancelEvent", 65536);
-EventManager::Get()->RegEventType("testEvent", 65537)
-#endif
-
 enum testEventTypes : uint32_t {
     cancelEvent = 65536,
     testEvent = 65537

--- a/tests/src/EventsTest/EventsTest.hpp
+++ b/tests/src/EventsTest/EventsTest.hpp
@@ -20,6 +20,16 @@
 
 namespace EventsTest {
 
+#ifdef DUCTTAPE_ENGINE_DEBUG
+EventManager::Get()->RegEventType("cancelEvent", 65536);
+EventManager::Get()->RegEventType("testEvent", 65537)
+#endif
+
+enum testEventTypes : uint32_t {
+    cancelEvent = 65536,
+    testEvent = 65537
+};
+
 class EventsTest : public Test {
 public:
     bool Run(int argc, char** argv);
@@ -30,7 +40,7 @@ public:
 
 class CancelEvent : public dt::Event {
 public:
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<dt::Event> Clone() const;
 };
 
@@ -55,7 +65,7 @@ public:
 class TestEvent : public dt::Event {
 public:
     TestEvent();
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<dt::Event> Clone() const;
     std::vector<uint64_t> anti_leak_payload;
 };

--- a/tests/src/FollowPathTest/FollowPathTest.cpp
+++ b/tests/src/FollowPathTest/FollowPathTest.cpp
@@ -31,7 +31,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 5.0) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/GuiTest/GuiTest.cpp
+++ b/tests/src/GuiTest/GuiTest.cpp
@@ -45,7 +45,7 @@ void Main::Click(MyGUI::Widget* _sender) {
 }
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 3.0) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/InputTest/InputTest.cpp
+++ b/tests/src/InputTest/InputTest.cpp
@@ -32,7 +32,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2.5) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/MouseCursorTest/MouseCursorTest.cpp
+++ b/tests/src/MouseCursorTest/MouseCursorTest.cpp
@@ -32,7 +32,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
 
         if(mRuntime >= 0 && mStep == 0) {

--- a/tests/src/MusicFadeTest/MusicFadeTest.cpp
+++ b/tests/src/MusicFadeTest/MusicFadeTest.cpp
@@ -29,7 +29,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2.0) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/NetworkTest/NetworkTest.cpp
+++ b/tests/src/NetworkTest/NetworkTest.cpp
@@ -26,6 +26,9 @@ bool NetworkTest::Run(int argc, char** argv) {
     std::shared_ptr<dt::NetworkEvent> ptr(new CustomNetworkEvent(0, CustomNetworkEvent::CLIENT));
     root.GetNetworkManager()->RegisterNetworkEventPrototype(ptr);
 
+    // register event types used in enum
+    root.GetEventManager()->RegEventType("customNetworkEvent", 65536);
+
     bool result = false;
     if(arg2.toLower() == "server") {
         result = RunServer();

--- a/tests/src/NetworkTest/NetworkTest.cpp
+++ b/tests/src/NetworkTest/NetworkTest.cpp
@@ -104,8 +104,8 @@ CustomNetworkEvent::CustomNetworkEvent(int data, Sender e)
     : mData(data),
       mEnum(e) {}
 
-const QString CustomNetworkEvent::GetType() const {
-    return "CUSTOMNETWORKEVENT";
+uint32_t CustomNetworkEvent::GetType() const {
+    return customNetworkEvent;
 }
 
 std::shared_ptr<dt::Event> CustomNetworkEvent::Clone() const {
@@ -124,7 +124,7 @@ CustomServerEventListener::CustomServerEventListener()
     : mDataReceived(0) {}
 
 void CustomServerEventListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "CUSTOMNETWORKEVENT") {
+    if(e->GetType() == customNetworkEvent) {
         std::shared_ptr<CustomNetworkEvent> c = std::dynamic_pointer_cast<CustomNetworkEvent>(e);
         if(c->mEnum == CustomNetworkEvent::CLIENT) {
             std::cout << "Server: received CustomNetworkEvent" << std::endl;
@@ -142,7 +142,7 @@ CustomClientEventListener::CustomClientEventListener()
     : mDataReceived(0) {}
 
 void CustomClientEventListener::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "CUSTOMNETWORKEVENT") {
+    if(e->GetType() == customNetworkEvent) {
         std::shared_ptr<CustomNetworkEvent> c = std::dynamic_pointer_cast<CustomNetworkEvent>(e);
         if(c->mEnum == CustomNetworkEvent::SERVER) {
             std::cout << "Client: received CustomNetworkEvent" << std::endl;

--- a/tests/src/NetworkTest/NetworkTest.hpp
+++ b/tests/src/NetworkTest/NetworkTest.hpp
@@ -29,10 +29,6 @@
 
 namespace NetworkTest {
 
-#ifdef DUCTTAPE_ENGINE_DEBUG
-EventManager::Get()->RegEventType("customNetworkEvent", 65536);
-#endif
-
 enum NetworkTestType {
     customNetworkEvent = 65536
 };

--- a/tests/src/NetworkTest/NetworkTest.hpp
+++ b/tests/src/NetworkTest/NetworkTest.hpp
@@ -29,6 +29,14 @@
 
 namespace NetworkTest {
 
+#ifdef DUCTTAPE_ENGINE_DEBUG
+EventManager::Get()->RegEventType("customNetworkEvent", 65536);
+#endif
+
+enum NetworkTestType {
+    customNetworkEvent = 65536
+};
+
 class NetworkTest : public Test {
     bool Run(int argc, char** argv);
     bool RunServer();
@@ -46,7 +54,7 @@ public:
     };
 
     CustomNetworkEvent(int data, Sender e);
-    const QString GetType() const;
+    uint32_t GetType() const;
     std::shared_ptr<dt::Event> Clone() const;
     void Serialize(dt::IOPacket& p);
 

--- a/tests/src/ParticlesTest/ParticlesTest.cpp
+++ b/tests/src/ParticlesTest/ParticlesTest.cpp
@@ -33,7 +33,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2.0) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/PhysicsSimpleTest/PhysicsSimpleTest.cpp
+++ b/tests/src/PhysicsSimpleTest/PhysicsSimpleTest.cpp
@@ -37,7 +37,7 @@ Main::Priority Main::GetEventPriority() const {
 }
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
 
         dt::Scene* testscene = GetScene("testscene");

--- a/tests/src/PhysicsStressTest/PhysicsStressTest.cpp
+++ b/tests/src/PhysicsStressTest/PhysicsStressTest.cpp
@@ -31,7 +31,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
 
         if(mRuntime > 10.0) {

--- a/tests/src/PrimitivesTest/PrimitivesTest.cpp
+++ b/tests/src/PrimitivesTest/PrimitivesTest.cpp
@@ -31,7 +31,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2.5) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/ScriptComponentTest/ScriptComponentTest.cpp
+++ b/tests/src/ScriptComponentTest/ScriptComponentTest.cpp
@@ -32,7 +32,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/ShadowsTest/ShadowsTest.cpp
+++ b/tests/src/ShadowsTest/ShadowsTest.cpp
@@ -31,7 +31,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         if(mRuntime > 2.5) {
             dt::StateManager::Get()->Pop(1);

--- a/tests/src/StatesTest/StatesTest.cpp
+++ b/tests/src/StatesTest/StatesTest.cpp
@@ -29,7 +29,7 @@ QString StatesTest::GetTestName() {
 ////////////////////////////////////////////////////////////////
 
 void SecondState::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         if(dt::Root::GetInstance().GetTimeSinceInitialize() > 4.0 && !mPopped) {
             dt::StateManager::Get()->Pop();
             mPopped = true;
@@ -68,7 +68,7 @@ FirstState::FirstState()
     : mCreated(false) {}
 
 void FirstState::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         if(dt::Root::GetInstance().GetTimeSinceInitialize() > 6.0) {
             dt::StateManager::Get()->Pop();
         }

--- a/tests/src/TerrainTest/TerrainTest.cpp
+++ b/tests/src/TerrainTest/TerrainTest.cpp
@@ -34,7 +34,7 @@ Main::Main()
       mBuilding(true) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         if(!mBuilding) {
             mRuntime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         }

--- a/tests/src/TextTest/TextTest.cpp
+++ b/tests/src/TextTest/TextTest.cpp
@@ -30,7 +30,7 @@ Main::Main()
     : mRuntime(0) {}
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         double time_diff = std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
         mRuntime += time_diff;
 

--- a/tests/src/TimerTest/TimerTest.cpp
+++ b/tests/src/TimerTest/TimerTest.cpp
@@ -77,7 +77,7 @@ void Main::OnInitialize() {
 }
 
 void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
-    if(e->GetType() == "DT_TIMERTICKEVENT") {
+    if(e->GetType() == dt::DT_TIMERTICKEVENT) {
         std::shared_ptr<dt::TimerTickEvent> t = std::dynamic_pointer_cast<dt::TimerTickEvent>(e);
         bool t1 = (t->GetMessageText() == "Timer 1 (event mode)");
         bool t2 = (t->GetMessageText() == "Timer 2 (thread mode)");
@@ -89,7 +89,7 @@ void Main::HandleEvent(std::shared_ptr<dt::Event> e) {
             mTimer2Count++;
             std::cout << "Timer tick " << mTimer2Count << ": " << dt::Utils::ToStdString(t->GetMessageText()) << std::endl;
         }
-    } else if(e->GetType() == "DT_BEGINFRAMEEVENT") {
+    } else if(e->GetType() == dt::DT_BEGINFRAMEEVENT) {
         mTotalTime += std::dynamic_pointer_cast<dt::BeginFrameEvent>(e)->GetFrameTime();
 
         if(mTotalTime >= 1.0) {


### PR DESCRIPTION
Custom events are just declared in custom enums on the custom event hpp files. I added a registry that uses strings to check and warn against id collisions, and it's in EventManager, instead of StringManager. Registering only needs to be done when debugging.
