### PR TITLE
Kill event system-little fixes about the volume

### DIFF
--- a/engine/src/Gui/GuiWidget.cpp
+++ b/engine/src/Gui/GuiWidget.cpp
@@ -73,10 +73,11 @@ void GuiWidget::SetPosition(int x, int y) {
 }
 
 void GuiWidget::SetSize(float width, float height) {
-    if(GetMyGUIWidget()->getSize().width != (int)width || GetMyGUIWidget()->getSize().height != (int)height) {
+    //DO NOT ADD THE TEST BELOW! OR YOU WILL NEVER SEE THE GUI!
+    //if(GetMyGUIWidget()->getSize().width != width || GetMyGUIWidget()->getSize().height != height) {
         GetMyGUIWidget()->setRealSize(width, height);
         emit SizeChanged(width, height);
-    }
+    //}
 }
 
 void GuiWidget::SetSize(int width, int height) {

--- a/tests/src/MusicFadeTest/MusicFadeTest.cpp
+++ b/tests/src/MusicFadeTest/MusicFadeTest.cpp
@@ -50,11 +50,11 @@ void Main::OnInitialize() {
     QString music1 = "test_music_intro.ogg";
     QString music2 = "test_music_loop.ogg";
 
-    float origin_vol = 9.f;
+    float origin_vol = 20.f;
     dt::MusicComponent* music_component1 = new dt::MusicComponent(music1);
     music_component1->SetVolume(origin_vol);
     dt::MusicComponent* music_component2 = new dt::MusicComponent(music2);
-    music_component2->SetVolume(origin_vol);
+    music_component2->SetVolume(0.0f);
 
     auto node = scene->AddChildNode(new dt::Node("music_node"));
     node->AddComponent(music_component1);

--- a/tests/src/MusicTest/MusicTest.cpp
+++ b/tests/src/MusicTest/MusicTest.cpp
@@ -28,7 +28,7 @@ bool MusicTest::Run(int argc, char** argv) {
     dt::Node* music_node = scene.AddChildNode(new dt::Node("music"));
     dt::MusicComponent* music_component = music_node->AddComponent(new dt::MusicComponent(music_file));
 
-    music_component->SetVolume(2);
+    music_component->SetVolume(40);
 
     auto resmgr = root.GetResourceManager();
 

--- a/tests/src/SoundTest/SoundTest.cpp
+++ b/tests/src/SoundTest/SoundTest.cpp
@@ -28,6 +28,7 @@ bool SoundTest::Run(int argc, char** argv) {
     dt::Node* sound = scene.AddChildNode(new dt::Node("sound"));
     dt::SoundComponent* sound_component = new dt::SoundComponent("test_music_loop_mono.ogg");
     sound->AddComponent(sound_component);
+    sound_component->SetMasterVolume(100.0f);
     sound_component->PlaySound();
     if(sound_component->GetSound().GetStatus() != sf::Sound::Playing) {
         std::cerr << "The sound is currently not playing." << std::endl;
@@ -41,7 +42,7 @@ bool SoundTest::Run(int argc, char** argv) {
 
     for(int i = 15; i > 0; --i) {
         // don't move it "through" the camera
-        sound->SetPosition(Ogre::Vector3(i, 10, 0));
+        sound->SetPosition(Ogre::Vector3(i, 0, 0));
         sf::Sleep(sound_component->GetSound().GetBuffer()->GetDuration()/50.f);
     }
 
@@ -78,8 +79,8 @@ bool SoundTest::Run(int argc, char** argv) {
 
     sound->RemoveComponent(sound_component->GetName());
     sound_component = new dt::SoundComponent("sad-trombone.wav");
-    sound_component->SetVolume(5.f);
     sound->AddComponent(sound_component);
+    sound_component->SetMasterVolume(30.0f);
     sound_component->PlaySound();
     if(sound_component->GetSound().GetStatus() != sf::Sound::Playing) {
         std::cerr << "The sound is currently not playing." << std::endl;


### PR DESCRIPTION
Some little fixes for the music and sound tests. Nothing can be heard before
because the volume value is too low and the distance from the listener is too far.
