### PR TITLE
issue 177, 178 and an extra for more consistency

### DIFF
--- a/engine/src/Audio/MusicComponent.hpp
+++ b/engine/src/Audio/MusicComponent.hpp
@@ -25,6 +25,7 @@ namespace dt {
 class DUCTTAPE_API MusicComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(MusicComponent)
     /**
      * Advanced constructor.
      * @param music_file_name The name of the music resource to play.

--- a/engine/src/Audio/SoundComponent.hpp
+++ b/engine/src/Audio/SoundComponent.hpp
@@ -28,6 +28,7 @@ namespace dt {
 class DUCTTAPE_API SoundComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(SoundComponent)
     /**
      * Advanced constructor.
      * @param sound_file The name of the sound resource to play.

--- a/engine/src/Graphics/BillboardSetComponent.cpp
+++ b/engine/src/Graphics/BillboardSetComponent.cpp
@@ -102,6 +102,10 @@ void BillboardSetComponent::SetOrientedCommon(const Ogre::Vector3& common_vector
     mBillboardSet->setCommonDirection(common_vector);
 }
 
+void BillboardSetComponent::SetOrientedCommon(float x, float y, float z) {
+    SetOrientedCommon(Ogre::Vector3(x, y, z));
+}
+
 void BillboardSetComponent::SetOrientedSelf() {
     mBillboardSet->setBillboardType(Ogre::BBT_ORIENTED_SELF);
 }
@@ -115,6 +119,10 @@ void BillboardSetComponent::SetPerpendicularCommon(const Ogre::Vector3& common_v
 void BillboardSetComponent::SetPerpendicularSelf(const Ogre::Vector3& up_vector) {
     mBillboardSet->setBillboardType(Ogre::BBT_PERPENDICULAR_SELF);
     mBillboardSet->setCommonUpVector(up_vector);
+}
+
+void BillboardSetComponent::SetPerpendicularSelf(float x, float y, float z) {
+    SetPerpendicularSelf(Ogre::Vector3(x, y, z));
 }
 
 void BillboardSetComponent::setDepthCheckEnabled(bool enabled) {

--- a/engine/src/Graphics/BillboardSetComponent.hpp
+++ b/engine/src/Graphics/BillboardSetComponent.hpp
@@ -30,6 +30,7 @@ namespace dt {
 class DUCTTAPE_API BillboardSetComponent : public Component {
 //    Q_OBJECT
 public:
+    DT_SERIALIZABLE(BillboardSetComponent)
     /**
       * Advanced constructor.
       * @param name The name of the Component.

--- a/engine/src/Graphics/BillboardSetComponent.hpp
+++ b/engine/src/Graphics/BillboardSetComponent.hpp
@@ -69,6 +69,7 @@ public:
       * @param common_vector The Billboards will rotate around this vector
       */  
     void SetOrientedCommon(const Ogre::Vector3& common_vector);
+    void SetOrientedCommon(float x, float y, float z);
     
     /**
       * Set Billboards to face the camera, rotating
@@ -91,6 +92,7 @@ public:
       * @param up_vector The X and Y axis of the billboards are determined by this vector.
       */  
     void SetPerpendicularSelf(const Ogre::Vector3& up_vector);  
+    void SetPerpendicularSelf(float x, float y, float z);
     
     /**
       * Sets whether or not each Pass renders with depth-buffer checking on or not.

--- a/engine/src/Graphics/CameraComponent.cpp
+++ b/engine/src/Graphics/CameraComponent.cpp
@@ -67,6 +67,10 @@ void CameraComponent::LookAt(Ogre::Vector3 target_point) {
     mNode->SetRotation(mCamera->getOrientation());
 }
 
+void CameraComponent::LookAt(float x, float y, float z) {
+    LookAt(Ogre::Vector3(x, y, z));
+}
+
 void CameraComponent::SetupViewport(float left, float top, float width, float height) {
     mViewport->setDimensions(left, top, width, height);
 }

--- a/engine/src/Graphics/CameraComponent.hpp
+++ b/engine/src/Graphics/CameraComponent.hpp
@@ -28,6 +28,7 @@ namespace dt {
 class DUCTTAPE_API CameraComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(CameraComponent)
     /**
       * Advanced constructor.
       * @name The name of the component.

--- a/engine/src/Graphics/CameraComponent.hpp
+++ b/engine/src/Graphics/CameraComponent.hpp
@@ -42,6 +42,7 @@ public:
     void OnUpdate(double time_diff);
     Ogre::Ray GetCameraToViewportRay(float x, float y);
     void LookAt(Ogre::Vector3 target_point);
+    void LookAt(float x, float y, float z);
 
     // sets the viewport size
     void SetupViewport(float left, float top, float width, float height);

--- a/engine/src/Graphics/LightComponent.cpp
+++ b/engine/src/Graphics/LightComponent.cpp
@@ -67,6 +67,10 @@ void LightComponent::SetColor(const Ogre::ColourValue color) {
     emit ColorChanged(color);
 }
 
+void LightComponent::SetColor(float r, float g, float b, float a) {
+    SetColor(Ogre::ColourValue(r, g, b, a));
+}
+
 Ogre::Light* LightComponent::GetOgreLight() const {
     return mLight;
 }

--- a/engine/src/Graphics/LightComponent.hpp
+++ b/engine/src/Graphics/LightComponent.hpp
@@ -29,6 +29,7 @@ namespace dt {
 class DUCTTAPE_API LightComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(LightComponent)
     /**
       * Advanced constructor.
       * @param name The name for this component.

--- a/engine/src/Graphics/LightComponent.hpp
+++ b/engine/src/Graphics/LightComponent.hpp
@@ -66,6 +66,7 @@ public slots:
       * @param color The color of the light.
       */
     void SetColor(const Ogre::ColourValue color);
+    void SetColor(float r, float g, float b, float a = 1);
 
 signals:
     void ColorChanged(const Ogre::ColourValue new_color);

--- a/engine/src/Graphics/MeshComponent.hpp
+++ b/engine/src/Graphics/MeshComponent.hpp
@@ -30,6 +30,7 @@ namespace dt {
 class DUCTTAPE_API MeshComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(MeshComponent)
     /**
       * Advanced constructor.
       * @param name The name of the Component.

--- a/engine/src/Graphics/ParticleSystemComponent.hpp
+++ b/engine/src/Graphics/ParticleSystemComponent.hpp
@@ -32,6 +32,7 @@ namespace dt {
 class DUCTTAPE_API ParticleSystemComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(ParticleSystemComponent)
     /**
       * Advanced constructor.
       * @see Component

--- a/engine/src/Graphics/TextComponent.cpp
+++ b/engine/src/Graphics/TextComponent.cpp
@@ -162,6 +162,10 @@ void TextComponent::SetColor(Ogre::ColourValue color) {
         emit ColorChanged();
 }
 
+void TextComponent::SetColor(float r, float g, float b, float a) {
+    SetColor(Ogre::ColourValue(r, g, b, a));
+}
+
 Ogre::ColourValue TextComponent::GetColor() const {
     return mColor;
 }
@@ -191,6 +195,10 @@ const QString& TextComponent::GetBackgroundMaterial() const {
 
 void TextComponent::SetPadding(Ogre::Vector2 padding) {
     mPadding = padding;
+}
+
+void TextComponent::SetPadding(float x, float y) {
+    SetPadding(Ogre::Vector2(x, y));
 }
 
 Ogre::Vector2 TextComponent::GetPadding() const {

--- a/engine/src/Graphics/TextComponent.hpp
+++ b/engine/src/Graphics/TextComponent.hpp
@@ -28,6 +28,7 @@ namespace dt {
 class DUCTTAPE_API TextComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(TextComponent)
     /**
       * Advanced constructor.
       */

--- a/engine/src/Graphics/TextComponent.hpp
+++ b/engine/src/Graphics/TextComponent.hpp
@@ -93,6 +93,7 @@ public:
       * @param padding The padding (spacing between text and panel border), in pixels.
       */
     void SetPadding(Ogre::Vector2 padding);
+    void SetPadding(float x, float y);
 
     /**
       * Returns the padding for the text box.
@@ -112,6 +113,7 @@ public slots:
       * @param color The font color.
       */
     void SetColor(Ogre::ColourValue color);
+    void SetColor(float r, float g, float b, float a = 1);
 
 signals:
     void TextChanged();

--- a/engine/src/Logic/FollowPathComponent.cpp
+++ b/engine/src/Logic/FollowPathComponent.cpp
@@ -70,6 +70,10 @@ void FollowPathComponent::AddPoint(Ogre::Vector3 point) {
     }
 }
 
+void FollowPathComponent::AddPoint(float x, float y, float z) {
+    AddPoint(Ogre::Vector3(x, y, z));
+}
+
 void FollowPathComponent::SetSpeed(float speed) {
     mTotalDuration = GetTotalLength() / speed;
 }

--- a/engine/src/Logic/FollowPathComponent.hpp
+++ b/engine/src/Logic/FollowPathComponent.hpp
@@ -58,6 +58,7 @@ public:
       * @param point The new point to add.
       */
     void AddPoint(Ogre::Vector3 point);
+    void AddPoint(float x, float y, float z);
 
     /**
       * Sets the speed with which the Node should travel along the path.

--- a/engine/src/Logic/FollowPathComponent.hpp
+++ b/engine/src/Logic/FollowPathComponent.hpp
@@ -30,6 +30,7 @@ namespace dt {
 class DUCTTAPE_API FollowPathComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(FollowPathComponent)
     /**
       * The mode which determines what happens when the Node reaches the end of the path.
       */
@@ -46,8 +47,6 @@ public:
       * @param mode The mode.
       */
     FollowPathComponent(Mode mode = SINGLE, const QString& name = "");
-
-    //virtual void HandleEvent(std::shared_ptr<Event> e);
 
     void OnCreate();
     void OnDestroy();

--- a/engine/src/Logic/ScriptComponent.hpp
+++ b/engine/src/Logic/ScriptComponent.hpp
@@ -25,6 +25,7 @@ namespace dt {
 class DUCTTAPE_API ScriptComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(ScriptComponent)
     /**
       * Advanced constructor.
       * @param name The name for this component.

--- a/engine/src/Logic/SimplePlayerComponent.cpp
+++ b/engine/src/Logic/SimplePlayerComponent.cpp
@@ -68,12 +68,12 @@ SimplePlayerComponent::SimplePlayerComponent(const QString& name)
 }*/
 
 void SimplePlayerComponent::OnCreate() {
-    if(!QObject::connect(InputManager::Get(), SIGNAL(sKeyPressed(const OIS::KeyEvent&)), 
+    if(!connect(InputManager::Get(), SIGNAL(sKeyPressed(const OIS::KeyEvent&)),
         this, SLOT(_HandleKeyboardInput(const OIS::KeyEvent&)))) {
             Logger::Get().Error("Cannot connect the key pressed signal with " + GetName()
                 + "'s keyboard input handling slot.");
     }
-    if(!QObject::connect(InputManager::Get(), SIGNAL(sMouseMoved(const OIS::MouseEvent&)), 
+    if(!connect(InputManager::Get(), SIGNAL(sMouseMoved(const OIS::MouseEvent&)),
         this, SLOT(_HandleMouseInput(const OIS::MouseEvent&)))) {
             Logger::Get().Error("Cannot connect the mouse moved signal with " + GetName()
                 + "'s mouse input handling slot.");

--- a/engine/src/Logic/SimplePlayerComponent.hpp
+++ b/engine/src/Logic/SimplePlayerComponent.hpp
@@ -32,6 +32,7 @@ namespace dt {
 class DUCTTAPE_API SimplePlayerComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(SimplePlayerComponent)
     /**
       * Advanced constructor.
       * @param name The name of the Component.

--- a/engine/src/Logic/TriggerComponent.cpp
+++ b/engine/src/Logic/TriggerComponent.cpp
@@ -14,12 +14,6 @@ TriggerComponent::TriggerComponent(const QString& name)
     : Component(name) {
 }
 
-//void TriggerComponent::HandleEvent(std::shared_ptr<Event> e) {
-//    if(e->GetType() == "trigger") {
-//
-//    }
-//}
-
 void TriggerComponent::OnCreate() {}
 
 void TriggerComponent::OnDestroy() {}

--- a/engine/src/Logic/TriggerComponent.hpp
+++ b/engine/src/Logic/TriggerComponent.hpp
@@ -33,8 +33,6 @@ public:
       */
     TriggerComponent(const QString& name = "");
 
-    /*virtual void HandleEvent(std::shared_ptr<Event> e);*/
-
     void OnCreate();
     void OnDestroy();
     void OnUpdate(double time_diff);

--- a/engine/src/Network/NetworkManager.hpp
+++ b/engine/src/Network/NetworkManager.hpp
@@ -50,9 +50,6 @@ public:
       */
     static NetworkManager* Get();
 
-//    void HandleEvent(std::shared_ptr<Event> e);
-   // virtual int GetEventPriority() const;
-
     /**
       * Binds the Socket used for the complete networking to the port given.
       * @param port The port to bind the socket to, or 0 to automatically select a free port.

--- a/engine/src/Physics/PhysicsBodyComponent.cpp
+++ b/engine/src/Physics/PhysicsBodyComponent.cpp
@@ -102,13 +102,24 @@ void PhysicsBodyComponent::ApplyCentralImpulse(const btVector3& impulse) {
     mBody->applyCentralImpulse(impulse);
 }
 
+void PhysicsBodyComponent::ApplyCentralImpulse(float x, float y, float z) {
+    ApplyCentralImpulse(btVector3(x, y, z));
+}
+
 void PhysicsBodyComponent::SetCentralForce(const btVector3& force) {
     mCentralForce = force;
 }
 
-void PhysicsBodyComponent::SetTorque(const btVector3& torque)
-{
+void PhysicsBodyComponent::SetCentralForce(float x, float y, float z) {
+    SetCentralForce(btVector3(x, y, z));
+}
+
+void PhysicsBodyComponent::SetTorque(const btVector3& torque) {
     mTorque = torque;
+}
+
+void PhysicsBodyComponent::SetTorque(float x, float y, float z) {
+    SetTorque(btVector3(x, y, z));
 }
 
 void PhysicsBodyComponent::SetCollisionMask(uint16_t collision_mask) {
@@ -143,12 +154,24 @@ void PhysicsBodyComponent::SetRestrictMovement(const btVector3& restriction) {
     mBody->setLinearFactor(restriction);
 }
 
+void PhysicsBodyComponent::SetRestrictMovement(float x, float y, float z) {
+    SetRestrictMovement(btVector3(x, y, z));
+}
+
 void PhysicsBodyComponent::SetRestrictRotation(const btVector3& restriction) {
     mBody->setAngularFactor(restriction);
 }
 
+void PhysicsBodyComponent::SetRestrictRotation(float x, float y, float z) {
+    SetRestrictRotation(btVector3(x, y, z));
+}
+
 void PhysicsBodyComponent::SetGravity(const btVector3& gravity) {
     mBody->setGravity(gravity);
+}
+
+void PhysicsBodyComponent::SetGravity(float x, float y, float z) {
+    SetGravity(btVector3(x, y, z));
 }
 
 void PhysicsBodyComponent::DisableSleep(bool disabled) {

--- a/engine/src/Physics/PhysicsBodyComponent.hpp
+++ b/engine/src/Physics/PhysicsBodyComponent.hpp
@@ -30,6 +30,7 @@ namespace dt {
 class DUCTTAPE_API PhysicsBodyComponent : public Component {
     Q_OBJECT
 public:
+    DT_SERIALIZABLE(PhysicsBodyComponent)
     /**
       * The type of collision shape that is constructed from the mesh.
       */

--- a/engine/src/Physics/PhysicsBodyComponent.hpp
+++ b/engine/src/Physics/PhysicsBodyComponent.hpp
@@ -60,8 +60,11 @@ public:
     void OnCollide(PhysicsBodyComponent* other_body);
     btRigidBody* GetRigidBody();
     void ApplyCentralImpulse(const btVector3& impulse);
+    void ApplyCentralImpulse(float x, float y, float z);
     void SetCentralForce(const btVector3& force);
+    void SetCentralForce(float x, float y, float z);
     void SetTorque(const btVector3& torque);
+    void SetTorque(float x, float y, float z);
     void SetCollisionMask(uint16_t collision_mask);
     void SetCollisionGroup(uint16_t collision_group);
     const btVector3 GetCentralForce() const;
@@ -73,6 +76,7 @@ public:
       * to disallow movement on that plane or 1 to allow it.
       */
     void SetRestrictMovement(const btVector3& restriction);
+    void SetRestrictMovement(float x, float y, float z);
 
     /**
       * Sets rotation restriction. This can be used to restrict a body's rotation to 1 or 2 dimensions.
@@ -80,12 +84,14 @@ public:
       * to disallow movement on that plane or 1 to allow it.
       */
     void SetRestrictRotation(const btVector3& restriction);
+    void SetRestrictRotation(float x, float y, float z);
 
     /**
       * Sets the gravity of the physics body.
       * @param gravity The new gravity.
       */
     void SetGravity(const btVector3& gravity);
+    void SetGravity(float x, float y, float z);
     
     /**
       * Prevents a body from sleeping when it rests. This decreases performance

--- a/tests/src/NetworkTest/NetworkTest.cpp
+++ b/tests/src/NetworkTest/NetworkTest.cpp
@@ -139,7 +139,7 @@ void CustomServerEventListener::_HandleEvent(std::shared_ptr<dt::NetworkEvent> e
 }
 
 void CustomServerEventListener::_Initialize() {
-    QObject::connect(dt::NetworkManager::Get(), SIGNAL(NewEvent(std::shared_ptr<dt::NetworkEvent>)),
+    connect(dt::NetworkManager::Get(), SIGNAL(NewEvent(std::shared_ptr<dt::NetworkEvent>)),
         this, SLOT(_HandleEvent(std::shared_ptr<dt::NetworkEvent>)));
 }
 
@@ -149,7 +149,7 @@ void CustomServerEventListener::_Initialize() {
 
 CustomClientEventListener::CustomClientEventListener()
     : mDataReceived(0) {
-        QObject::connect(dt::NetworkManager::Get(), SIGNAL(NewEvent(std::shared_ptr<dt::NetworkEvent>)),
+        connect(dt::NetworkManager::Get(), SIGNAL(NewEvent(std::shared_ptr<dt::NetworkEvent>)),
             this, SLOT(_HandleEvent(std::shared_ptr<dt::NetworkEvent>)));
         _Initialize();
 }
@@ -165,7 +165,7 @@ void CustomClientEventListener::_HandleEvent(std::shared_ptr<dt::NetworkEvent> e
 }
 
 void CustomClientEventListener::_Initialize() {
-    QObject::connect(dt::NetworkManager::Get(), SIGNAL(NewEvent(std::shared_ptr<dt::NetworkEvent>)),
+    connect(dt::NetworkManager::Get(), SIGNAL(NewEvent(std::shared_ptr<dt::NetworkEvent>)),
         this, SLOT(_HandleEvent(std::shared_ptr<dt::NetworkEvent>)));
 }
 

--- a/tests/src/TimerTest/TimerTest.cpp
+++ b/tests/src/TimerTest/TimerTest.cpp
@@ -55,10 +55,10 @@ void Main::OnInitialize() {
     mTimer1 = std::shared_ptr<dt::Timer>(new dt::Timer("Timer 1 (event mode)", 0.1, true, false));
     mTimer2 = std::shared_ptr<dt::Timer>(new dt::Timer("Timer 2 (thread mode)", 0.2, true, true));
 
-    QObject::connect(mTimer1.get(), SIGNAL(TimerTicked(const QString&, double)),
-                     this, SLOT(_TimerCallback(QString)));
-    QObject::connect(mTimer2.get(), SIGNAL(TimerTicked(const QString&, double)),
-                     this, SLOT(_TimerCallback(QString)), Qt::DirectConnection);
+    connect(mTimer1.get(), SIGNAL(TimerTicked(const QString&, double)),
+            this, SLOT(_TimerCallback(QString)));
+    connect(mTimer2.get(), SIGNAL(TimerTicked(const QString&, double)),
+            this, SLOT(_TimerCallback(QString)), Qt::DirectConnection);
 
     mTotalTime = 0;
 }


### PR DESCRIPTION
notes:
177 - consistent connect usage: used just connect everywhere except in the signals test, because a non-QObject class is calling the method. I can easily change them all to QObject::connect though.

178 - register remaining core components: I assumed core components was every component in the engine itself.

consistent float methods: added extra methods to most component methods which took only a vector or Ogre::colourvalue as their variable. So "void applyCentralTorque(btVector3 torque)" got an extra fuction called "void applyCentralTorque(float x, float y, float z)" and just makes a btVector3 and calls the first function. This was for ease of use and consistency, because I noticed some functions in Node did this.
 If there was anything other than a vector as the input, I didn't make an extra function, so two vector input still needs two vectors.
