### PR TITLE
Just what the commit says.

### DIFF
--- a/engine/src/Gui/GuiWidget.hpp
+++ b/engine/src/Gui/GuiWidget.hpp
@@ -80,8 +80,9 @@ public:
       * @returns A pointer to the new widget.
       */
     template <typename WidgetType>
-    WidgetType* CreateChild(const QString& name) {
-        _AddChild(new WidgetType(name));
+    WidgetType* AddChildWidget(WidgetType* widget) {
+        const QString& name = widget->GetName();
+        _AddChild(widget);
         FindChild(name)->Initialize();
         return dynamic_cast<WidgetType*>(FindChild(name));
     }

--- a/samples/fps/src/FPS.cpp
+++ b/samples/fps/src/FPS.cpp
@@ -16,7 +16,8 @@
 #include <OgreProcedural.h>
 
 void Main::OnInitialize() {
-    dt::ResourceManager::Get()->AddDataPath(QDir("./fps/data"));
+    //dt::ResourceManager::Get()->AddDataPath(QDir("../samples/fps/data"));
+    dt::ResourceManager::Get()->AddResourceLocation("../samples/fps/data", "FileSystem", true);
     dt::ResourceManager::Get()->AddResourceLocation("gui","FileSystem", true);
     dt::ResourceManager::Get()->AddResourceLocation("","FileSystem");
     dt::ResourceManager::Get()->AddResourceLocation("crate", "FileSystem");

--- a/samples/fps/src/FPS.cpp
+++ b/samples/fps/src/FPS.cpp
@@ -16,8 +16,7 @@
 #include <OgreProcedural.h>
 
 void Main::OnInitialize() {
-    //dt::ResourceManager::Get()->AddDataPath(QDir("../samples/fps/data"));
-    dt::ResourceManager::Get()->AddResourceLocation("../samples/fps/data", "FileSystem", true);
+    dt::ResourceManager::Get()->AddDataPath(QDir("../samples/fps/data"));
     dt::ResourceManager::Get()->AddResourceLocation("gui","FileSystem", true);
     dt::ResourceManager::Get()->AddResourceLocation("","FileSystem");
     dt::ResourceManager::Get()->AddResourceLocation("crate", "FileSystem");

--- a/samples/fps/src/FPS.cpp
+++ b/samples/fps/src/FPS.cpp
@@ -16,7 +16,7 @@
 #include <OgreProcedural.h>
 
 void Main::OnInitialize() {
-    dt::ResourceManager::Get()->AddDataPath(QDir("../samples/fps/data"));
+    dt::ResourceManager::Get()->AddDataPath(QDir("./fps/data"));
     dt::ResourceManager::Get()->AddResourceLocation("gui","FileSystem", true);
     dt::ResourceManager::Get()->AddResourceLocation("","FileSystem");
     dt::ResourceManager::Get()->AddResourceLocation("crate", "FileSystem");

--- a/samples/fps/src/Player.cpp
+++ b/samples/fps/src/Player.cpp
@@ -35,9 +35,9 @@ void Player::OnInitialize() {
     this->AddComponent(mJumpingSound);
 
     dt::GuiRootWindow& win = dt::GuiManager::Get()->GetRootWindow();
-    mHUDAmmo = win.CreateChild<dt::GuiButton>("HUD_ammo");
-    mHUDHealth = win.CreateChild<dt::GuiButton>("HUD_health");
-    mHUDClip = win.CreateChild<dt::GuiButton>("HUD_clip");
+    mHUDAmmo = win.AddChildWidget(new dt::GuiButton("HUD_ammo"));
+    mHUDHealth = win.AddChildWidget(new dt::GuiButton("HUD_health"));
+    mHUDClip = win.AddChildWidget(new dt::GuiButton("HUD_clip"));
     auto screen_rect = win.GetMyGUIWidget()->getAbsoluteRect();
 
     mHUDHealth->SetSize(100, 30);

--- a/samples/script/src/main.cpp
+++ b/samples/script/src/main.cpp
@@ -188,7 +188,7 @@ public:
         // create GUI
         dt::GuiRootWindow& win = dt::GuiManager::Get()->GetRootWindow();
 
-        mOutput = win.CreateChild<dt::GuiEditBox>("output");
+        mOutput = win.AddChildWidget(new dt::GuiEditBox("output"));
         mOutput->SetPosition(10, 10);
         mOutput->SetSize(780, 550);
         MyGUI::EditBox* output = dynamic_cast<MyGUI::EditBox*>(mOutput->GetMyGUIWidget());
@@ -197,7 +197,7 @@ public:
         output->setEditReadOnly(true);
         output->setTextAlign(MyGUI::Align::Bottom | MyGUI::Align::Left);
 
-        mInput = win.CreateChild<dt::GuiEditBox>("input");
+        mInput = win.AddChildWidget(new dt::GuiEditBox("input"));
         mInput->SetPosition(10, 570);
         mInput->SetSize(700, 20);
         MyGUI::EditBox* input = dynamic_cast<MyGUI::EditBox*>(mInput->GetMyGUIWidget());
@@ -207,11 +207,11 @@ public:
         input->eventKeyButtonPressed += MyGUI::newDelegate(this, &Main::KeyPressed);
         input->setTextAlign(MyGUI::Align::Bottom | MyGUI::Align::Left);
 
-        mButton = win.CreateChild<dt::GuiButton>("button");
+        mButton = win.AddChildWidget(new dt::GuiButton("button"));
         mButton->SetPosition(720, 570);
         mButton->SetSize(70, 20);
         mButton->SetCaption("Run");
-        dynamic_cast<MyGUI::Button*>(mButton->GetMyGUIWidget())->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::SubmitClicked);
+        mButton->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::SubmitClicked);
 
 
         InfoFunction(nullptr, dt::ScriptManager::Get()->GetScriptEngine());

--- a/tests/src/GuiStateTest/GuiStateTest.cpp
+++ b/tests/src/GuiStateTest/GuiStateTest.cpp
@@ -44,12 +44,11 @@ void SecondState::OnInitialize() {
     mesh->SetCastShadows(false);
 
     dt::GuiRootWindow& rootWindow = dt::GuiManager::Get()->GetRootWindow();
-    mReturnButton = rootWindow.CreateChild<dt::GuiButton>("return");
+    mReturnButton = rootWindow.AddChildWidget(new dt::GuiButton("return"));
     mReturnButton->SetCaption("Return");
     mReturnButton->SetSize(250, 100);
     mReturnButton->SetPosition(100, 100);
-    dynamic_cast<MyGUI::Button*>(mReturnButton->GetMyGUIWidget())->eventMouseButtonClick
-        += MyGUI::newDelegate(this, &SecondState::OnClick);
+    mReturnButton->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &SecondState::OnClick);
 }
 
 void SecondState::OnDeinitialize() {
@@ -89,12 +88,11 @@ void FirstState::OnInitialize() {
     text->SetFontSize(64);
 
     dt::GuiRootWindow& rootWindow = dt::GuiManager::Get()->GetRootWindow();
-    mNextButton = rootWindow.CreateChild<dt::GuiButton>("next");
+    mNextButton = rootWindow.AddChildWidget(new dt::GuiButton("next"));
     mNextButton->SetCaption("Next");
     mNextButton->SetSize(250, 100);
     mNextButton->SetPosition(100, 100);
-    dynamic_cast<MyGUI::Button*>(mNextButton->GetMyGUIWidget())->eventMouseButtonClick
-        += MyGUI::newDelegate(this, &FirstState::OnClick);
+    mNextButton->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &FirstState::OnClick);
 }
 
 void FirstState::OnDeinitialize() {

--- a/tests/src/GuiTest/GuiTest.cpp
+++ b/tests/src/GuiTest/GuiTest.cpp
@@ -64,29 +64,29 @@ void Main::OnInitialize() {
     // GUI
     dt::GuiRootWindow& win = dt::GuiManager::Get()->GetRootWindow();
 
-    dt::GuiButton* button1 = win.CreateChild<dt::GuiButton>("b1");
+    dt::GuiButton* button1 = win.AddChildWidget(new dt::GuiButton("b1"));
     button1->SetCaption("Campaign");
     button1->SetPosition(10, 10);
     button1->SetSize(200, 30);
-    dynamic_cast<MyGUI::Button*>(button1->GetMyGUIWidget())->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
+    button1->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
 
-    dt::GuiButton* button2 = win.CreateChild<dt::GuiButton>("b2");
+    dt::GuiButton* button2 = win.AddChildWidget(new dt::GuiButton("b2"));
     button2->SetCaption("Tutorial");
     button2->SetPosition(10, 50);
     button2->SetSize(200, 30);
-    dynamic_cast<MyGUI::Button*>(button2->GetMyGUIWidget())->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
+    button2->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
 
-    dt::GuiButton* button3 = win.CreateChild<dt::GuiButton>("b3");
+    dt::GuiButton* button3 = win.AddChildWidget(new dt::GuiButton("b3"));
     button3->SetCaption("Options");
     button3->SetPosition(10, 90);
     button3->SetSize(200, 30);
-    dynamic_cast<MyGUI::Button*>(button3->GetMyGUIWidget())->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
+    button3->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
 
-    dt::GuiButton* button4 = win.CreateChild<dt::GuiButton>("b4");
+    dt::GuiButton* button4 = win.AddChildWidget(new dt::GuiButton("b4"));
     button4->SetCaption("Exit");
     button4->SetPosition(10, 130);
     button4->SetSize(200, 30);
-    dynamic_cast<MyGUI::Button*>(button4->GetMyGUIWidget())->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
+    button4->GetMyGUIWidget()->eventMouseButtonClick += MyGUI::newDelegate(this, &Main::Click);
 }
 
 void Main::UpdateStateFrame(double simulation_frame_time) {


### PR DESCRIPTION
old method:

```
win.CreateChild<dt::GuiButton>("button1");
```

new method:

```
win.AddChildWidget(new dt::GuiButton("button1"));
```

new method is more like node:

```
node->AddChildNode(new dt::Node("node2"));
node->AddComponent(new dt::MeshComponent("mesh1"));
```

also changed all the 

```
dynamic_cast<dt::GuiButton*>(widget->getMyGUIWidget())->eventMousButtonClick
```

to

```
widget->getMyGUIWidget()->eventMouseButtonClick
```

because GuiWidget has these events, too.

tested on my end, and it seems to work without any errors.
edit: I'll never get github's code tags to ignore "<" and ">"
edit2: got it.
